### PR TITLE
add parallel to DESCRIPTION, otherwise must manually load when thread…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,8 +39,9 @@ Depends:
     magrittr,
     S4Vectors (>= 0.9.25),
     BiocGenerics,
-    GenomicRanges
-Collate: 
+    GenomicRanges,
+    parallel
+Collate:
     'AllClasses.R'
     'AnnotationGenome.R'
     'AnnotationPeaks.R'


### PR DESCRIPTION
Add parallel package to DESCRIPTION, otherwise ArchR fails when archr_threads > 1 unless manually library(parallel).